### PR TITLE
Bump minikube to 1.25.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - 'feature*'
-      - 'feature/*'
       - 'feature_*'
-      - 'hotfix*'
+      - 'feature/*'
       - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 20 * * *'
@@ -26,7 +26,7 @@ jobs:
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.minikube'
         fetch-depth: 0
@@ -34,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.minikube'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -46,14 +47,14 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 8
+      max-parallel: 6
       matrix:
         IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.minikube'
 
@@ -69,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.minikube'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.minikube'
 
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.minikube'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 minikube_app: minikube
-minikube_version: 1.24.0
+minikube_version: 1.25.1
 minikube_os: linux
 minikube_arch: amd64
 minikube_dl_url: https://github.com/kubernetes/{{ minikube_app }}/releases/download/v{{ minikube_version }}/{{ minikube_app }}-{{ minikube_os }}-{{ minikube_arch }}
@@ -29,7 +29,7 @@ minikube_bin_permission_mode: '0755'
 Variable                     | Description
 ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------
 minikube_app                 | Defines the app to install i.e. **minikube**
-minikube_version             | Defined to dynamically fetch the desired version to install. Defaults to: **1.24.0**
+minikube_version             | Defined to dynamically fetch the desired version to install. Defaults to: **1.25.1**
 minikube_os                  | Defines os type. Defaults to: **linux**
 minikube_arch                | Defines os architecture. Defaults to: **amd64**
 minikube_dl_url              | Defines URL to download the minikube binary from.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for minikube
 
 minikube_app: minikube
-minikube_version: 1.24.0
+minikube_version: 1.25.1
 minikube_os: linux
 minikube_arch: amd64
 minikube_dl_url: https://github.com/kubernetes/{{ minikube_app }}/releases/download/v{{ minikube_version }}/{{ minikube_app }}-{{ minikube_os }}-{{ minikube_arch }}


### PR DESCRIPTION
- Utilize github actions/checkout@v2 and Python 3.10.0 in build-and-test workflow
- Utilize github actions/checkout@v2 and Python 3.10.0 in release workflow
- Bump `minikube` to 1.25.1